### PR TITLE
Add support for Service Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /public/build
 /node_modules
 /public/sw-toolbox.js
-/public/service-worker.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /public/build
 /node_modules
+/public/sw-toolbox.js
+/public/service-worker.js

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "url": "http://github.com/insin/react-hn.git"
   },
   "scripts": {
-    "build": "npm run lint && nwb build",
-    "lint": "eslint .",
+    "build": "npm run lint && cp node_modules/sw-toolbox/sw-toolbox.js public/sw-toolbox.js && nwb build && npm run precache",
+    "lint": "eslint src",
     "lint:fix": "eslint --fix .",
-    "start": "nwb serve"
+    "start": "nwb serve",
+    "precache": "sw-precache --root=public --config=sw-precache-config.json"
   },
   "dependencies": {
     "events": "1.1.0",
@@ -28,6 +29,8 @@
   },
   "devDependencies": {
     "eslint-config-jonnybuchanan": "2.0.3",
-    "nwb": "0.8.1"
+    "nwb": "0.8.1",
+    "sw-precache": "^3.1.1",
+    "sw-toolbox": "^3.1.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,16 +15,35 @@
     <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('./service-worker.js', {
-          scope: './'
-        })
-        .catch(function(error) {
-          console.error('Error registering service worker:' + error);
-        });
-      navigator.serviceWorker.addEventListener('controllerchange', function() {
-        window.location.reload();
+        scope: './'
+      })
+      .then(function(registration) {
+        if (typeof registration.update === 'function') {
+          registration.update();
+        }
+
+        registration.onupdatefound = function() {
+          if (navigator.serviceWorker.controller) {
+            var installingWorker = registration.installing;
+
+            installingWorker.onstatechange = function() {
+              switch (installingWorker.state) {
+                case 'installed':
+                  break;
+                case 'redundant':
+                  throw new Error('The installing ' +
+                                  'service worker became redundant.');
+                default:
+                  // Ignore
+              }
+            };
+          }
+        };
+      }).catch(function(e) {
+        console.error('Error during service worker registration:', e);
       });
     } else {
-      console.log('service worker not supported');
+      console.log('service worker is not supported');
     }
   </script>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -12,5 +12,20 @@
     <div id="app"></div>
     <script src="build/vendor.js"></script>
     <script src="build/app.js"></script>
+    <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('./service-worker.js', {
+          scope: './'
+        })
+        .catch(function(error) {
+          console.error('Error registering service worker:' + error);
+        });
+      navigator.serviceWorker.addEventListener('controllerchange', function() {
+        window.location.reload();
+      });
+    } else {
+      console.log('service worker not supported');
+    }
+  </script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -18,10 +18,6 @@
         scope: './'
       })
       .then(function(registration) {
-        if (typeof registration.update === 'function') {
-          registration.update();
-        }
-
         registration.onupdatefound = function() {
           if (navigator.serviceWorker.controller) {
             var installingWorker = registration.installing;

--- a/public/runtime-caching.js
+++ b/public/runtime-caching.js
@@ -1,0 +1,21 @@
+// global.toolbox is defined in a different script, sw-toolbox.js, which is part of the
+// https://github.com/GoogleChrome/sw-toolbox project.
+// That sw-toolbox.js script must be executed first, so it needs to be listed before this in the
+// importScripts() call that the parent service worker makes.
+(function(global) {
+  'use strict'
+
+  // See https://github.com/GoogleChrome/sw-toolbox/blob/6e8242dc328d1f1cfba624269653724b26fa94f1/README.md#toolboxroutergeturlpattern-handler-options
+  // and https://github.com/GoogleChrome/sw-toolbox/blob/6e8242dc328d1f1cfba624269653724b26fa94f1/README.md#toolboxfastest
+  // for more details on how this handler is defined and what the toolbox.fastest strategy does.
+  global.toolbox.router.get('/(.*)', global.toolbox.fastest, {
+    origin: /\.(?:googleapis|gstatic|firebaseio)\.com$/
+  })
+  global.toolbox.router.get('/(.+)', global.toolbox.fastest, {
+  	  origin: 'https://hacker-news.firebaseio.com'
+  })
+  global.toolbox.router.get('/(.+)', global.toolbox.fastest, {
+  	  origin: 'https://s-usc1c-nss-136.firebaseio.com'
+  })
+})(self)
+

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,2 @@
+// This file is intentionally without code.
+// It's present so that service worker registration will work when serving from the 'public' directory.

--- a/sw-precache-config.json
+++ b/sw-precache-config.json
@@ -1,0 +1,8 @@
+{
+  "importScripts": [
+    "sw-toolbox.js",
+    "runtime-caching.js"
+  ],
+  "stripPrefix": "public/",
+  "verbose": true
+}


### PR DESCRIPTION
As part of #20, this PR adds support for Service Worker registration and precaching of static files at build-time using [sw-precache](https://github.com/GoogleChrome/sw-precache). 

When running `npm run build` this will generate a new SW script that enables precaching all of the files in the `public` directory.  Build output looks like this:

```
nwb: clean-app
nwb: build-react-app
Hash: a9fff369472398985a85
Version: webpack 1.12.14
Time: 9561ms
        Asset     Size  Chunks             Chunk Names
    vendor.js   344 kB       0  [emitted]  vendor
       app.js  50.3 kB       1  [emitted]  app
vendor.js.map  2.58 MB       0  [emitted]  vendor
   app.js.map   276 kB       1  [emitted]  app

> react-hn@1.4.10 precache /Users/addyo/projects/addy-forks/react-hn
> sw-precache --root=public --config=sw-precache-config.json

Skipping static resource "public/build/vendor.js.map" (2.58 MB) - max size is 2.1 MB
Total precache size is about 706.33 kB for 10 resources.
public/service-worker.js has been generated with the service worker contents.
```

Here's the app being served with DevTools in Network > offline mode where you can see the static assets being served up from the SW Cache API:

<img width="1432" alt="screen shot 2016-04-03 at 20 45 30" src="https://cloud.githubusercontent.com/assets/110953/14234535/1220e11e-f9dd-11e5-9930-224e315102c8.png">

This will also work for other views, like show HN:

<img width="1430" alt="screen shot 2016-04-03 at 20 47 09" src="https://cloud.githubusercontent.com/assets/110953/14234543/46cd48bc-f9dd-11e5-8210-628e742fee7b.png">
