### PR TITLE
Responsive UI tweak for mobile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -306,3 +306,10 @@ span.control:hover {
 .UserProfile h4 {
   margin: 0 0 1em 0;
 }
+
+@media only screen and (max-width: 750px) and (min-width: 300px) {
+  .App__wrap {
+    width: 100%;
+    margin: 0px auto;
+  }  
+}


### PR DESCRIPTION
At present, the `react-hn` UI looks a little like this on a mobile device (e.g Nexus 5X), with additional margin and whitespace occupying the edges.

<img width="1198" alt="screen shot 2016-04-04 at 10 32 21" src="https://cloud.githubusercontent.com/assets/110953/14246399/bd413914-fa5e-11e5-89ff-ce6e8f09d3d1.png">

This PR includes a media query with two tweaks which:

- Drop the extra margin around the application wrapper container
- Drop the percentage based width for the wrapper, allowing the app to take up the full width on devices

It looks like this on a phone now:

<img width="1098" alt="screen shot 2016-04-04 at 10 32 57" src="https://cloud.githubusercontent.com/assets/110953/14246450/11757630-fa5f-11e5-86b2-7dcf51812f5f.png">

These changes don't impact how it currently renders on desktop.

Side: we might want to figure out how we want to tackle the navigation menu on mobile. In master, the Settings link currently overlaps with other nav items.