### PR TITLE
Adds Firebase API read-through caching (fixes #25)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "events": "1.1.0",
     "firebase": "2.4.2",
+    "firetruck.js": "^0.1.1",
     "history": "2.0.1",
     "react": "15.0.1",
     "react-dom": "15.0.1",

--- a/src/services/HNService.js
+++ b/src/services/HNService.js
@@ -1,6 +1,7 @@
-var Firebase = require('firebase')
+var Firetruck = require('firetruck.js')
 
-var api = new Firebase('https://hacker-news.firebaseio.com/v0')
+var api = new Firetruck('https://hacker-news.firebaseio.com/v0')
+api.restore()
 
 function fetchItem(id, cb) {
   itemRef(id).once('value', function(snapshot) {


### PR DESCRIPTION
This change adds support for a read-through caching adapter on top of the Firebase API that fixes #25. It enables support for caching comment-threads and other non-UI content responses being returned from Firebase for `react-hn` views. We use localForage/IDB for the caching layer, falling back to localStorage.

This change uses https://github.com/GoogleChrome/firetruck (not yet public, but going through Google open-source releasing atm). Both @insin and @NekR should have access to look at what's there atm. It's not particularly fancy. The adapter doesn't yet support `set()` operations but since this project is mostly just reading HN data, I think we should be fine.

DevTools > Resources > IndexedDB showing records cached:

<img width="828" alt="screen shot 2016-04-25 at 14 00 02" src="https://cloud.githubusercontent.com/assets/110953/14784537/07b812d4-0aee-11e6-973b-835f8f05e4ed.png">

Here's a demo of a built version of the app still being able to view comments when the network is killed:
📹 https://www.youtube.com/watch?v=Nz_f9Gfii6w&feature=youtu.be

There are quite a few perf improvements that can be made to Firetruck (we start to hit slow reads when you're looking at large (e.g 300+) comment threads and could optimize bottlenecks like `JSON.stringify()`, but I can look at that next. Consider this a better-than-what-we-have-now addition :)

### Things we can/should do better in future

* Avoid filling up IndexedDB by having some sort of cache-expiration model for older cached entries
* Properly catch attempts to `set` that won't be cached and provide a meaningful message. Even better would be scheduling writes, but again, React HN doesn't really need this
* Be smarter about when we read from IndexedDB vs. re-fetching from the network

