### PR TITLE
Revert firetruck.js for now

### DIFF
--- a/src/services/HNService.js
+++ b/src/services/HNService.js
@@ -1,7 +1,6 @@
-var Firetruck = require('firetruck.js')
+var Firebase = require('firebase')
 
-var api = new Firetruck('https://hacker-news.firebaseio.com/v0')
-api.restore()
+var api = new Firebase('https://hacker-news.firebaseio.com/v0')
 
 function fetchItem(id, cb) {
   itemRef(id).once('value', function(snapshot) {


### PR DESCRIPTION
@NekR @insin This change reverts Firetruck (caching for all content) until I can find a clean way of solving the perf regressions in #29. I've been playing with a few different caching strategies this week and don't want to block any other work we could be doing/deploying for now.