### PR TITLE
Fixes #30 - avoid overlapping 'Settings' with other nav items on small screens

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -311,5 +311,17 @@ span.control:hover {
   .App__wrap {
     width: 100%;
     margin: 0px auto;
-  }  
+  }
+
+  /* Hide the App title homelink on narrow viewports */
+  .App__homelink {
+    display: none;
+  }
+}
+
+/* Hide the Settings link on iPhone 5 */
+@media (device-height: 568px) and (device-width: 320px) and (-webkit-min-device-pixel-ratio: 2) {
+  .App__settings {
+    display: none;
+  } 
 }

--- a/src/App.js
+++ b/src/App.js
@@ -44,7 +44,7 @@ var App = React.createClass({
     return <div className="App" onClick={this.state.showSettings && this.toggleSettings}>
       <div className="App__wrap">
       <div className="App__header">
-        <img src="img/logo.png" width="16" height="16" alt="" />{' '}
+        <Link to="/news" className="App__homelinkicon"><img src="img/logo.png" width="16" height="16" alt="" /></Link>{' '}
         <Link to="/news" activeClassName="active" className="App__homelink">React HN</Link>{' '}
         <Link to="/newest" activeClassName="active">new</Link>{' | '}
         <Link to="/newcomments" activeClassName="active">comments</Link> {' | '}


### PR DESCRIPTION
What is this fixing? Basically...

<img width="233" alt="screen shot 2016-05-06 at 18 59 14" src="https://cloud.githubusercontent.com/assets/110953/15081845/ad860870-13bc-11e6-9bd2-f2c8eac13cf7.png">


This PR includes two changes:

- Hides the ‘React HN’ homelink on narrow viewports, allowing Settings to be displayed without any overlap. Where this isn’t enough (primarily iPhone 5) we also hide the Settings link. I think this is better than some of the nav being inaccessible (and we can come up with a better solution later)

- If we go ahead with this change, it also makes the ReactHN logo link to /news, so we have a replacement for the `React HN` link being hidden on smaller screens. I thought this was a reasonable compromise 🐱 

Screenshots below:

iPhone 6:
<img width="477" alt="screen shot 2016-05-06 at 18 35 58" src="https://cloud.githubusercontent.com/assets/110953/15081760/480884f0-13bc-11e6-99e9-9a3f170ac2c4.png">

iPhone 5:
<img width="410" alt="screen shot 2016-05-06 at 18 32 36" src="https://cloud.githubusercontent.com/assets/110953/15081770/51e26040-13bc-11e6-9a8f-a72bcbba9451.png">

Nexus 5X:
<img width="459" alt="screen shot 2016-05-06 at 18 36 06" src="https://cloud.githubusercontent.com/assets/110953/15081778/596d61de-13bc-11e6-989e-aace9aa502de.png">

iPad (like desktop, 'React HN' and Settings still render fine):

<img width="608" alt="screen shot 2016-05-06 at 18 36 19" src="https://cloud.githubusercontent.com/assets/110953/15081787/6391076a-13bc-11e6-862a-ea223b6d3885.png">

cc @insin @NekR 
