### PR TITLE
Introduce Offline Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "firebase": "2.4.2",
     "firetruck.js": "0.1.1",
     "history": "2.1.1",
+    "isomorphic-fetch": "^2.2.1",
     "react": "15.0.2",
     "react-dom": "15.0.2",
     "react-router": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "npm run lint && cp node_modules/sw-toolbox/sw-toolbox.js public/sw-toolbox.js && nwb build && npm run precache",
-    "lint": "eslint src",
-    "lint:fix": "eslint --fix .",
+    "lint": "./node_modules/eslint-config-jonnybuchanan/bin/lint.js src",
+    "lint:fix": "./node_modules/eslint-config-jonnybuchanan/bin/lint.js --fix .",
     "start": "nwb serve",
     "precache": "sw-precache --root=public --config=sw-precache-config.json"
   },

--- a/public/runtime-caching.js
+++ b/public/runtime-caching.js
@@ -12,10 +12,10 @@
     origin: /\.(?:googleapis|gstatic|firebaseio)\.com$/
   })
   global.toolbox.router.get('/(.+)', global.toolbox.fastest, {
-  	  origin: 'https://hacker-news.firebaseio.com'
+  	    origin: 'https://hacker-news.firebaseio.com'
   })
   global.toolbox.router.get('/(.+)', global.toolbox.fastest, {
-  	  origin: 'https://s-usc1c-nss-136.firebaseio.com'
+  	    origin: 'https://s-usc1c-nss-136.firebaseio.com'
   })
 })(self)
 

--- a/src/Comment.js
+++ b/src/Comment.js
@@ -3,6 +3,7 @@ var ReactFireMixin = require('reactfire')
 
 var CommentThreadStore = require('./stores/CommentThreadStore')
 var HNService = require('./services/HNService')
+var HNServiceRest = require('./services/HNServiceRest')
 var SettingsStore = require('./stores/SettingsStore')
 
 var CommentMixin = require('./mixins/CommentMixin')
@@ -86,7 +87,17 @@ var Comment = React.createClass({
   },
 
   bindFirebaseRef() {
-    this.bindAsObject(HNService.itemRef(this.props.id), 'comment', this.handleFirebaseRefCancelled)
+    if (SettingsStore.offlineMode) {
+      HNServiceRest.itemRef(this.props.id).then(function(res) {
+        return res.json()
+      }).then(function(snapshot) {
+        this.replaceState({ comment: snapshot })
+      }.bind(this))
+    }
+    else {
+      this.bindAsObject(HNService.itemRef(this.props.id), 'comment', this.handleFirebaseRefCancelled)
+    }
+
     if (this.timeout) {
       this.timeout = null
     }

--- a/src/PermalinkedComment.js
+++ b/src/PermalinkedComment.js
@@ -4,6 +4,7 @@ var withRouter = require('react-router/lib/withRouter')
 
 var CommentThreadStore = require('./stores/CommentThreadStore')
 var HNService = require('./services/HNService')
+var HNServiceRest = require('./services/HNServiceRest')
 var SettingsStore = require('./stores/SettingsStore')
 var UpdatesStore = require('./stores/UpdatesStore')
 
@@ -32,7 +33,16 @@ var PermalinkedComment = React.createClass({
   },
 
   componentWillMount() {
-    this.bindAsObject(HNService.itemRef(this.props.params.id), 'comment')
+    if (SettingsStore.offlineMode) {
+      HNServiceRest.itemRef(this.props.params.id).then(function(res) {
+        return res.json()
+      }).then(function(snapshot) {
+        this.replaceState({ comment: snapshot })
+      }.bind(this))
+    }
+    else {
+      this.bindAsObject(HNService.itemRef(this.props.params.id), 'comment')
+    }
     if (this.state.comment.id) {
       this.commentLoaded(this.state.comment)
     }

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -42,7 +42,7 @@ var Settings = React.createClass({
           <label htmlFor="offlineMode">
             <input type="checkbox" name="offlineMode" id="offlineMode" checked={SettingsStore.offlineMode}/> Offline Mode
           </label>
-          <p>Show items flagged as dead.</p>
+          <p>Cache comments and content offline.</p>
         </div>
         <div className="Settings__setting Settings__setting--checkbox">
           <label htmlFor="showDead">

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -39,6 +39,12 @@ var Settings = React.createClass({
           <p>Show "reply" links to Hacker News</p>
         </div>
         <div className="Settings__setting Settings__setting--checkbox">
+          <label htmlFor="offlineMode">
+            <input type="checkbox" name="offlineMode" id="offlineMode" checked={SettingsStore.offlineMode}/> Offline Mode
+          </label>
+          <p>Show items flagged as dead.</p>
+        </div>
+        <div className="Settings__setting Settings__setting--checkbox">
           <label htmlFor="showDead">
             <input type="checkbox" name="showDead" id="showDead" checked={SettingsStore.showDead}/> show dead
           </label>

--- a/src/StoryListItem.js
+++ b/src/StoryListItem.js
@@ -3,6 +3,7 @@ var ReactFireMixin = require('reactfire')
 
 var StoryCommentThreadStore = require('./stores/StoryCommentThreadStore')
 var HNService = require('./services/HNService')
+var HNServiceRest = require('./services/HNServiceRest')
 var SettingsStore = require('./stores/SettingsStore')
 var StoryStore = require('./stores/StoryStore')
 
@@ -94,8 +95,18 @@ var StoryListItem = React.createClass({
    * initialise its comment thread state.
    */
   initLiveItem(props) {
-    // If we were given a cached item to display initially, it will be replaced
-    this.bindAsObject(HNService.itemRef(props.id), 'item')
+    if (SettingsStore.offlineMode) {
+      HNServiceRest.itemRef(props.id).then(function(res) {
+        return res.json()
+      }).then(function(snapshot) {
+        this.replaceState({ item: snapshot })
+      }.bind(this))
+    }
+    else {
+      // If we were given a cached item to display initially, it will be replaced
+      this.bindAsObject(HNService.itemRef(props.id), 'item')
+    }
+
     this.threadState = StoryCommentThreadStore.loadState(props.id)
     this.props.store.addListener(props.id, this.updateThreadState)
   },

--- a/src/services/HNServiceRest.js
+++ b/src/services/HNServiceRest.js
@@ -1,0 +1,62 @@
+/*global fetch*/
+require('isomorphic-fetch')
+/*
+A version of HNService which concumes the Firebase REST
+endpoint (https://www.firebase.com/docs/rest/api/). This
+is used when a user has enabled 'Offline Mode' in the
+Settings panel and ensures responses can be easily fetched
+and cached when paired with Service Worker. This cannot be
+trivially done using just Web Sockets with the default
+Firebase API and provides a sufficient fallback that works.
+ */
+var endPoint = 'https://hacker-news.firebaseio.com/v0'
+var options = {
+  method: 'GET',
+  headers: {
+    'Accept': 'application/json'
+  }
+}
+
+function storiesRef(path) {
+  return fetch(endPoint + '/' + path + '.json', options)
+}
+
+function itemRef(id) {
+  return fetch(endPoint + '/item/' + id + '.json', options)
+}
+
+function userRef(id) {
+  return fetch(endPoint + '/user/' + id + '.json', options)
+}
+
+function updatesRef() {
+  return fetch(endPoint + '/updates/items/' + '.json', options)
+}
+
+function fetchItem(id, cb) {
+  itemRef(id).once('value', function(snapshot) {
+    cb(snapshot.val())
+  })
+}
+
+function fetchItems(ids, cb) {
+  var items = []
+  ids.forEach(function(id) {
+    fetchItem(id, addItem)
+  })
+  function addItem(item) {
+    items.push(item)
+    if (items.length >= ids.length) {
+      cb(items)
+    }
+  }
+}
+
+module.exports = {
+  fetchItem,
+  fetchItems,
+  storiesRef,
+  itemRef,
+  userRef,
+  updatesRef
+}

--- a/src/stores/ItemStore.js
+++ b/src/stores/ItemStore.js
@@ -1,8 +1,9 @@
 var HNService = require('../services/HNService')
+var HNServiceRest = require('../services/HNServiceRest')
 
 var StoryStore = require('./StoryStore')
 var UpdatesStore = require('./UpdatesStore')
-
+var SettingsStore = require('./SettingsStore')
 var commentParentLookup = {}
 var titleCache = {}
 
@@ -72,7 +73,12 @@ var ItemStore = {
       setImmediate(cb, cachedItem)
     }
     else {
-      HNService.fetchItem(id, cb)
+      if (SettingsStore.offlineMode) {
+        HNServiceRest.fetchItem(id, cb)
+      }
+      else {
+        HNService.fetchItem(id, cb)
+      }
     }
   },
 

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -10,6 +10,7 @@ var SettingsStore = {
   showDeleted: false,
   titleFontSize: 18,
   listSpacing: 16,
+  offlineMode: false,
 
   load() {
     var json = storage.get(STORAGE_KEY)
@@ -25,7 +26,8 @@ var SettingsStore = {
       showDead: this.showDead,
       showDeleted: this.showDeleted,
       titleFontSize: this.titleFontSize,
-      listSpacing: this.listSpacing
+      listSpacing: this.listSpacing,
+      offlineMode: this.offlineMode
     }))
   }
 }

--- a/src/stores/StoryStore.js
+++ b/src/stores/StoryStore.js
@@ -1,6 +1,8 @@
 var {EventEmitter} = require('events')
 
 var HNService = require('../services/HNService')
+var HNServiceRest = require('../services/HNServiceRest')
+var SettingsStore = require('./SettingsStore')
 
 var extend = require('../utils/extend')
 
@@ -91,20 +93,36 @@ class StoryStore extends EventEmitter {
    * Handle story id snapshots from Firebase.
    */
   onStoriesUpdated(snapshot) {
-    idCache[this.type] = snapshot.val()
+    if (SettingsStore.offlineMode) {
+      idCache[this.type] = snapshot
+    }
+    else {
+      idCache[this.type] = snapshot.val()
+    }
     populateStoryList(this.type)
     this.emit('update', this.getState())
   }
 
   start() {
-    firebaseRef = HNService.storiesRef(this.type)
-    firebaseRef.on('value', this.onStoriesUpdated)
+    if (SettingsStore.offlineMode) {
+      HNServiceRest.storiesRef(this.type).then(function(res) {
+        return res.json()
+      }).then(function(snapshot) {
+        this.onStoriesUpdated(snapshot)
+      }.bind(this))
+    }
+    else {
+      firebaseRef = HNService.storiesRef(this.type)
+      firebaseRef.on('value', this.onStoriesUpdated)
+    }
     window.addEventListener('storage', this.onStorage)
   }
 
   stop() {
     if (firebaseRef !== null) {
-      firebaseRef.off()
+      if (!SettingsStore.offlineMode) {
+        firebaseRef.off()
+      }
       firebaseRef = null
     }
     window.removeEventListener('storage', this.onStorage)
@@ -124,16 +142,28 @@ extend(StoryStore, {
    * Deserialise caches from sessionStorage.
    */
   loadSession() {
-    idCache = parseJSON(window.sessionStorage.idCache, {})
-    itemCache = parseJSON(window.sessionStorage.itemCache, {})
+    if (SettingsStore.offlineMode) {
+      idCache = parseJSON(window.localStorage.idCache, {})
+      itemCache = parseJSON(window.localStorage.itemCache, {})
+    }
+    else {
+      idCache = parseJSON(window.sessionStorage.idCache, {})
+      itemCache = parseJSON(window.sessionStorage.itemCache, {})
+    }
   },
 
   /**
    * Serialise caches to sessionStorage as JSON.
    */
   saveSession() {
-    window.sessionStorage.idCache = JSON.stringify(idCache)
-    window.sessionStorage.itemCache = JSON.stringify(itemCache)
+    if (SettingsStore.offlineMode) {
+      window.localStorage.setItem('idCache', JSON.stringify(idCache))
+      window.localStorage.setItem('itemCache', JSON.stringify(itemCache))
+    }
+    else {
+      window.sessionStorage.idCache = JSON.stringify(idCache)
+      window.sessionStorage.itemCache = JSON.stringify(itemCache)
+    }
   }
 })
 

--- a/src/stores/UpdatesStore.js
+++ b/src/stores/UpdatesStore.js
@@ -1,6 +1,8 @@
 var EventEmitter = require('events').EventEmitter
 
 var HNService = require('../services/HNService')
+var HNServiceRest = require('../services/HNServiceRest')
+var SettingsStore = require('./SettingsStore')
 
 var {UPDATES_CACHE_SIZE} = require('../utils/constants')
 var extend = require('../utils/extend')
@@ -93,7 +95,6 @@ function handleUpdateItems(items) {
       updatesCache.stories[item.id] = item
     }
   }
-
   populateUpdates()
   UpdatesStore.emit('updates', updates)
 }
@@ -111,16 +112,27 @@ var UpdatesStore = extend(new EventEmitter(), {
 
   start() {
     if (updatesRef === null) {
-      updatesRef = HNService.updatesRef()
-      updatesRef.on('value', function(snapshot) {
-        HNService.fetchItems(snapshot.val(), handleUpdateItems)
-      })
+      if (SettingsStore.offlineMode) {
+        HNServiceRest.updatesRef().then(function(res) {
+          return res.json()
+        }).then(function(snapshot) {
+          HNServiceRest.fetchItems(snapshot, handleUpdateItems)
+        })
+      }
+      else {
+        updatesRef = HNService.updatesRef()
+        updatesRef.on('value', function(snapshot) {
+          HNService.fetchItems(snapshot.val(), handleUpdateItems)
+        })
+      }
     }
   },
 
   stop() {
-    updatesRef.off()
-    updatesRef = null
+    if (!SettingsStore.offlineMode) {
+      updatesRef.off()
+      updatesRef = null
+    }
   },
 
   getUpdates() {


### PR DESCRIPTION
Video demo: https://www.youtube.com/watch?v=-HwAqwH2qq4

**What is this?**

`Offline Mode` introduces a new option to the Settings pane that provides full, reliable caching support for  content flowing through the React HN app. It uses the Service Worker Cache API as a backing store and conditionally switches to the Firebase REST API if offline is enabled, otherwise uses the real-time API as we normally do today. When this mode is enabled, we also switch to local storage over session storage to persist 'sessions' loaded from the user's homescreen.

**How does it work?** 

[Previous](https://github.com/insin/react-hn/issues/29) efforts to add offline caching for our content have assumed we would be working against the full, real-time Firebase API (which, for HN means updates flowing in every few seconds). This was complex to manage and quite susceptible to slowness, IDB thrashing (even from a Web Worker) and didn't give us what we needed on mobile. 

Instead, I've introduced `HNServiceRest`. This special-cases Offline Mode so that it switches to using the Firebase REST API (which just gives you a bunch of `.json` URLs for content entries). This is trivial for us to now cache at runtime using `sw-toolbox` (which we've already been including). 

**What browsers has this been tested in?**

Offline Mode has been tested as working in both Chrome, Opera and Firefox. In browsers without support for Service Worker (e.g Safari stable), it will still work the same way as it does today. I had considered hiding the `Offline Mode` option if SW wasn't supported, but might think about doing this as a follow-up. 

**Does this negatively impact the default experience in any way?**

As `Offline Mode` needs to be manually switched on, the default experience for all users will still be real-time data from the Firebase HN endpoint. As long as I've got the casing right, this feature should be considered an enhancement. 

cc @insin @NekR 