### PR TITLE
Add gzip compression for static assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,15 @@
   },
   "main": "server.js",
   "dependencies": {
+    "compression": "1.6.2",
     "ejs": "^2.4.1",
+    "eslint-config-jonnybuchanan": "2.0.3",
     "events": "1.1.0",
     "express": "^4.13.4",
     "firebase": "2.4.2",
     "history": "2.1.1",
     "isomorphic-fetch": "^2.2.1",
+    "nwb": "0.8.1",
     "react": "15.0.2",
     "react-dom": "15.0.2",
     "react-router": "2.4.0",
@@ -36,10 +39,8 @@
     "reactfire": "0.7.0",
     "scroll-behavior": "0.5.0",
     "setimmediate": "1.0.4",
-    "url-parse": "^1.1.1",
-    "eslint-config-jonnybuchanan": "2.0.3",
-    "nwb": "0.8.1",
     "sw-precache": "^3.1.1",
-    "sw-toolbox": "^3.1.1"
+    "sw-toolbox": "^3.1.1",
+    "url-parse": "^1.1.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 var express = require('express')
+var compression = require('compression')
 var React = require('react')
 var renderToString = require('react-dom/server').renderToString
 var ReactRouter = require('react-router')
@@ -10,6 +11,7 @@ var app = express()
 app.set('view engine', 'ejs')
 app.set('views', process.cwd() + '/src/views')
 app.set('port', (process.env.PORT || 5000))
+app.use(compression())
 app.use(express.static('public'))
 
 app.get('*', function(req, res) {


### PR DESCRIPTION
This pull request adds the [compression](https://github.com/expressjs/compression) middleware to the Express server in order to serve gzipped assets.

The diff is a bit weird for `package.json` due to the dependencies not being ordered. `npm install --save` automatically ordered them, and will do so for future changes, so I recommend just keeping it ordered.

Anyway, thanks for creating this project! I enjoy using it.