### PR TITLE
Fix: Issue#34, solution for links overflowing in comments section

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -61,6 +61,8 @@ span.control:hover {
   background-color: #f5f5f5;
   font-size: 13.3333px;
   font-family: Verdana, Geneva, sans-serif;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 .App__header {
   color: #00d8ff;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -61,8 +61,6 @@ span.control:hover {
   background-color: #f5f5f5;
   font-size: 13.3333px;
   font-family: Verdana, Geneva, sans-serif;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
 }
 .App__header {
   color: #00d8ff;
@@ -118,6 +116,8 @@ span.control:hover {
   color: #fff !important;
 }
 .App__content {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 .App__footer {
   margin-top: 1em;


### PR DESCRIPTION
#34 
https://www.w3.org/TR/css-text-3/#overflow-wrap

'overflow-wrap' has apparently replaced 'word-wrap' in css3 specifications.
adding 'word-wrap' for legacy support.