### PR TITLE
Fixes #44 - app.yaml: always default to https

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,6 +2,9 @@ runtime: nodejs
 vm: true
 env_variables:
   NODE_ENV: production
-
+handlers:
+- url: /.*
+  script: IGNORED
+  secure: always
 skip_files:
   - ^(.*/)?.*/node_modules/.*$


### PR DESCRIPTION
Reviewer: @insin 

I've updated the current deploy on GAE to use this configuration and it appears to be defaulting fine now. This change reflects that in master.