### PR TITLE
Add support for server-side rendering Top Stories & Comments

### DIFF
--- a/hn-server-fetch.js
+++ b/hn-server-fetch.js
@@ -42,9 +42,37 @@ exports.fetchNews = function(page) {
 	})		
 }
 
+function renderNestedComment(data) {
+	return '<div class="Comment__kids">' +
+		        '<div class="Comment Comment--level1">' +
+		            '<div class="Comment__content">' +
+		                '<div class="Comment__meta"><span class="Comment__collapse" tabindex="0">[–]</span> ' +
+		                    '<a class="Comment__user" href="#/user/' + data.user + '">' + data.user + '</a> ' +
+		                    '<time>' + data.time_ago + '</time> ' +
+		                    '<a href="#/comment/' + data.id + '">link</a></div> ' +
+		                '<div class="Comment__text">' +
+		                    '<div>' + data.content +'</div> ' +
+		                    '<p><a href="https://news.ycombinator.com/reply?id=' + data.id + '">reply</a></p>' +
+		                '</div>' +
+		            '</div>' +
+		        '</div>' +
+		    '</div>'
+}
+
+function generateNestedCommentString(data) {
+	var output = ''
+	data.comments.forEach(function(comment) {
+		output+= renderNestedComment(comment)
+		if (comment.comments) {
+			output+= generateNestedCommentString(comment)
+		} 
+	})
+	return output
+}
+
 /**
  * Fetch details of the story/post/item with (nested) comments
- * TODO: Nested comments.
+ * TODO: Add article summary at top of nested comment thread
  */
 exports.fetchItem = function(itemId) {
 	return fetch('https://node-hnapi.herokuapp.com/item/' + itemId).then(function(response) {
@@ -52,19 +80,20 @@ exports.fetchItem = function(itemId) {
 	}).then(function(json) {
 		var comments = ''
 		json.comments.forEach(function(data, index) {
-			var comment = '<div class="Comment Comment--level0">' +
+			var comment = '<div class="Item__kids">' + 
+			'<div class="Comment Comment--level0">' +
 		    '<div class="Comment__content">' +
-		        '<div class="Comment__meta"><span class="Comment__collapse" tabindex="0"></span>' +
-		            '<a class="Comment__user" href="#/user/' + data.user + '">' + data.user + '</a>' +
-		            '<time>' + data.time_ago + '</time>' +
-		            '<a href="#/comment/' + data.id + '">link</a></div>' +
+		        '<div class="Comment__meta"><span class="Comment__collapse" tabindex="0">[–]</span> ' +
+		            '<a class="Comment__user" href="#/user/' + data.user + '">' + data.user + '</a> ' +
+		            '<time>' + data.time_ago + '</time> ' +
+		            '<a href="#/comment/' + data.id + '">link</a></div> ' +
 		        '<div class="Comment__text">' +
-		            '<div>' + data.content +'</div>' + 
+		            '<div>' + data.content +'</div> ' + 
 		            '<p><a href="https://news.ycombinator.com/reply?id=' + data.id + '">reply</a></p>' +
 		        '</div>' +
 		    '</div>' +
-			'</div>'
-			comments += comment
+		   '</div>'
+			comments += generateNestedCommentString(data) + '</div>' + comment
 		})
 		return comments
 	})

--- a/hn-server-fetch.js
+++ b/hn-server-fetch.js
@@ -1,0 +1,71 @@
+require('isomorphic-fetch')
+
+/*
+The official Firebase API (https://github.com/HackerNews/API) requires multiple network
+connections to be made in order to fetch the list of Top Stories (indices) and then the
+summary content of these stories. Directly requesting these resources makes server-side
+rendering cumbersome as it is slow and ultimately requires that you maintain your own 
+cache to ensure full server renders are efficient. 
+
+To work around this problem, we can use one of the unofficial Hacker News APIs, specifically
+https://github.com/cheeaun/node-hnapi which directly returns the Top Stories and can cache 
+responses for 10 minutes. In ReactHN, we can use the unofficial API for a static server-side
+render and then 'hydrate' this once our components have mounted to display the real-time 
+experience. 
+
+The benefit of this is clients loading up the app that are on flakey networks (or lie-fi)
+can still get a fast render of content before the rest of our JavaScript bundle is loaded.
+ */
+
+/**
+ * Fetch top stories
+ */
+exports.fetchNews = function(page) {
+	page = page || ''
+	return fetch('http://node-hnapi.herokuapp.com/news' + page).then(function(response) {
+	  return response.json()
+	}).then(function(json) {
+	  var stories = '<ol class="Items__list" start="1">'
+	  json.forEach(function(data, index) {
+	      var story = '<li class="ListItem" style="margin-bottom: 16px;">' +
+	          '<div class="Item__title" style="font-size: 18px;"><a href="' + data.url + '">' + data.title + '</a> ' +
+	          '<span class="Item__host">(' + data.domain + ')</span></div>' +
+	          '<div class="Item__meta"><span class="Item__score">' + data.points + ' points</span> ' +
+	          '<span class="Item__by">by <a href="https://news.ycombinator.com/user?id=' + data.user + '">' + data.user + '</a></span> ' +
+	          '<time class="Item__time">' + data.time_ago + ' hours ago</time> ' +
+	          '<a href="/news/story/' + data.id + '">' + data.comments_count + ' comments</a></div>'
+	      '</li>'
+	      stories += story
+	  })
+	  stories += '</ol>'
+	  return stories
+	})		
+}
+
+/**
+ * Fetch details of the story/post/item with (nested) comments
+ * TODO: Nested comments.
+ */
+exports.fetchItem = function(itemId) {
+	return fetch('https://node-hnapi.herokuapp.com/item/' + itemId).then(function(response) {
+		return response.json()
+	}).then(function(json) {
+		var comments = ''
+		json.comments.forEach(function(data, index) {
+			var comment = '<div class="Comment Comment--level0">' +
+		    '<div class="Comment__content">' +
+		        '<div class="Comment__meta"><span class="Comment__collapse" tabindex="0"></span>' +
+		            '<a class="Comment__user" href="#/user/' + data.user + '">' + data.user + '</a>' +
+		            '<time>' + data.time_ago + '</time>' +
+		            '<a href="#/comment/' + data.id + '">link</a></div>' +
+		        '<div class="Comment__text">' +
+		            '<div>' + data.content +'</div>' + 
+		            '<p><a href="https://news.ycombinator.com/reply?id=' + data.id + '">reply</a></p>' +
+		        '</div>' +
+		    '</div>' +
+			'</div>'
+			comments += comment
+		})
+		return comments
+	})
+}

--- a/hn-server-fetch.js
+++ b/hn-server-fetch.js
@@ -32,7 +32,7 @@ exports.fetchNews = function(page) {
 	          '<span class="Item__host">(' + data.domain + ')</span></div>' +
 	          '<div class="Item__meta"><span class="Item__score">' + data.points + ' points</span> ' +
 	          '<span class="Item__by">by <a href="https://news.ycombinator.com/user?id=' + data.user + '">' + data.user + '</a></span> ' +
-	          '<time class="Item__time">' + data.time_ago + ' hours ago</time> ' +
+	          '<time class="Item__time">' + data.time_ago + ' </time> | ' +
 	          '<a href="/news/story/' + data.id + '">' + data.comments_count + ' comments</a></div>'
 	      '</li>'
 	      stories += story

--- a/package.json
+++ b/package.json
@@ -24,11 +24,14 @@
   "main": "server.js",
   "dependencies": {
     "ejs": "^2.4.1",
+    "eslint-config-jonnybuchanan": "2.0.3",
     "events": "1.1.0",
     "express": "^4.13.4",
     "firebase": "2.4.2",
     "history": "2.1.1",
     "isomorphic-fetch": "^2.2.1",
+    "nwb": "0.8.1",
+    "object-assign": "^4.1.0",
     "react": "15.0.2",
     "react-dom": "15.0.2",
     "react-router": "2.4.0",
@@ -36,10 +39,8 @@
     "reactfire": "0.7.0",
     "scroll-behavior": "0.5.0",
     "setimmediate": "1.0.4",
-    "url-parse": "^1.1.1",
-    "eslint-config-jonnybuchanan": "2.0.3",
-    "nwb": "0.8.1",
     "sw-precache": "^3.1.1",
-    "sw-toolbox": "^3.1.1"
+    "sw-toolbox": "^3.1.1",
+    "url-parse": "^1.1.1"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,9 @@ var SettingsStore = require('./stores/SettingsStore')
 var App = React.createClass({
   getInitialState() {
     return {
-      showSettings: false
+      showSettings: false,
+      showChildren: false,
+      prebootHTML: this.props.params.prebootHTML
     }
   },
 
@@ -20,6 +22,11 @@ var App = React.createClass({
     UpdatesStore.loadSession()
     if (typeof window === 'undefined') return
     window.addEventListener('beforeunload', this.handleBeforeUnload)
+  },
+
+  componentDidMount() {
+    // Empty the prebooted HTML and hydrate using live results from Firebase
+    this.setState({ prebootHTML: '', showChildren: true })
   },
 
   componentWillUnmount() {
@@ -58,7 +65,8 @@ var App = React.createClass({
         {this.state.showSettings && <Settings key="settings"/>}
       </div>
       <div className="App__content">
-        {this.props.children}
+        <div dangerouslySetInnerHTML={{ __html: this.state.prebootHTML }}/>
+        {this.state.showChildren ? this.props.children : ''}
       </div>
       <div className="App__footer">
         <a href="https://github.com/insin/react-hn">insin/react-hn</a>

--- a/src/Stories.js
+++ b/src/Stories.js
@@ -67,7 +67,7 @@ var Stories = React.createClass({
 
     // Display a list of placeholder items while we're waiting for the initial
     // list of story ids to load from Firebase.
-    if (this.state.stories.length === 0 && this.state.ids.length === 0) {
+    if (this.state.stories.length === 0 && this.state.ids.length === 0 && this.getPageNumber() > 0) {
       var dummyItems = []
       for (var i = page.startIndex; i < page.endIndex; i++) {
         dummyItems.push(

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -29,7 +29,7 @@
     <meta name="msapplication-TileColor" content="#222222">
     <meta name="msapplication-TileImage" content="img/mstile-144x144.png">
     <meta name="msapplication-config" content="img/browserconfig.xml">
-    
+    <base href="/">
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>


### PR DESCRIPTION
**Please don't merge in just yet. This work requires some discussion about the UX**

This set of changes adds server-side rendering for both Top Stories (index) and comment threads. It enables React HN to deliver content quickly, especially useful for flakey/slow networks or where our vendor/app bundle hasn't been fully loaded yet (sometimes a few seconds on slow connections). It works with JavaScript disabled too.

Demo: https://react-hn-ssr.appspot.com
Video: https://www.youtube.com/watch?v=E1YNRc3Kfag&feature=youtu.be
[Lighthouse](https://github.com/GoogleChrome/lighthouse/) scores: 100/100

## How

I investigated a few different ways SSR could be added over in #27. The approach I landed on moves most of the work over into Express, with minimal changes to our React code to support 'preboot' data and hydration. We populate the view in `componentWillMount` (server/client) and hydrate in `componentDidMount` (client).  

Originally, I tried to do full server-side rendering using the Firebase SDK. This involved a large number of network requests to be resolved for stories and comments, which ended up taking anywhere up to a minute. In a normal server environment, we would start adding in a caching layer here to avoid each visit having to incur this cost. 

Thankfully, there exists a third-party (unofficial) Hacker News API we can call, which does support caching and provides story and comment data in a slightly more friendly format. Because the data format is different enough to what we currently rely on in the rest of our React components (in particular, our templates), I decided to replicate the output in EJS templates allowing us to get the same look and feel once output. 

## Some screenshots from WebPageTest

First meaningful paint happening at 0.6s on cable with SSR compared to 2.1s with our current build:

![screen shot 2016-06-09 at 14 30 41](https://cloud.githubusercontent.com/assets/110953/15931259/e3700592-2e4e-11e6-8ffe-63676266e31d.png)

Hydration to real-time content, occurring at roughly the same time as our current build:

![screen shot 2016-06-09 at 14 32 15](https://cloud.githubusercontent.com/assets/110953/15931285/07cfa4ce-2e4f-11e6-9af0-2b182f466e4d.png)

http://www.webpagetest.org/video/compare.php?tests=160609_TS_1H8W,160609_SD_1H8Y if you'd like to look at the data directly.

## UX

Perhaps the biggest change this PR adds is a change to the ReactHN UX. If you navigate to the demo with JS off/on a throttled connection, content will load/display quickly and eventually 'update' to real-time. On a fast connection, you'll see the server-rendered content and then very shortly after the hydrated real-time experience. It's a little like FOUC. This only happens for the first page of top story results (after which the experience is per usual), however I'm interested in hearing what others think about the experience. Is it okay? Does it feel unnatural? If the latter, there are a few options we have, such as delaying hydration until a future time (based on an interval). Alternative ideas are also welcome.
