### PR TITLE
npm run postinstall failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /public/build
 /node_modules
 /public/sw-toolbox.js
-dist/*
-!dist/.gitignore
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /public/build
 /node_modules
 /public/sw-toolbox.js
-dist
+dist/*
+!dist/.gitignore

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
#70 When running `npm run postinstall` script after repository clone, the post install fails due to dist dir not existing... A lot of different ways to deal with this, but this seemed pretty easy.