### PR TITLE
Add lang attributes to html tag

### DIFF
--- a/public/index-static.html
+++ b/public/index-static.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">


### PR DESCRIPTION
Adds a default lang="en" attribute to the html tags, which was bringing down the accessibility score. 