### PR TITLE
Add .eslintrc for text editors/plugins that rely on it

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "./node_modules/eslint-config-jonnybuchanan/.eslintrc"
+  ]
+}


### PR DESCRIPTION
Some editors/plugins (vim) rely on .eslintrc to be present in the root of a project so I added it linking to the eslint-config-jonnybuchanan config. 